### PR TITLE
Alfred

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -40,6 +40,10 @@ const ItemPreview = (props) => {
         src={item.image}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
+        onError={({ currentTarget }) => {
+          currentTarget.onerror = null; // prevents looping
+          currentTarget.src="/placeholder.png";
+        }}
       />
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -66,5 +66,6 @@ const ItemPreview = (props) => {
     </div>
   );
 };
+//test
 
 export default connect(() => ({}), mapDispatchToProps)(ItemPreview);


### PR DESCRIPTION
When users added items without images it would display a broken image I used an onError handler on the img tag grabbed the src is there was an error and set it to the default image in the placeholer.png
